### PR TITLE
Jets generate trails only on use.

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -68,6 +68,7 @@
 	icon_state = initial(icon_state)
 	ion_trail.stop()
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(user, COMSIG_MOVABLE_PRE_MOVE)
 	user.remove_movespeed_modifier(MOVESPEED_ID_JETPACK)
 
 /obj/item/tank/jetpack/proc/move_react(mob/user)

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -17,6 +17,7 @@
 /obj/item/tank/jetpack/Initialize()
 	. = ..()
 	ion_trail = new
+	ion_trail.auto_process = FALSE
 	ion_trail.set_up(src)
 
 /obj/item/tank/jetpack/populate_gas()
@@ -57,6 +58,7 @@
 	icon_state = "[initial(icon_state)]-on"
 	ion_trail.start()
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/move_react)
+	RegisterSignal(user, COMSIG_MOVABLE_PRE_MOVE, .proc/pre_move_react)
 	if(full_speed)
 		user.add_movespeed_modifier(MOVESPEED_ID_JETPACK, priority=100, multiplicative_slowdown=-0.5, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
 
@@ -84,6 +86,9 @@
 	if(length(user.client.keys_held & user.client.movement_keys))//You use jet when press keys. yes.
 		allow_thrust(0.01, user)
 
+/obj/item/tank/jetpack/proc/pre_move_react(mob/user)
+	ion_trail.oldposition = get_turf(src)
+
 /obj/item/tank/jetpack/proc/allow_thrust(num, mob/living/user)
 	if(!on)
 		return
@@ -98,6 +103,7 @@
 
 	var/turf/T = get_turf(user)
 	T.assume_air(removed)
+	ion_trail.generate_effect()
 
 	return TRUE
 
@@ -137,6 +143,7 @@
 
 	var/turf/T = get_turf(user)
 	T.assume_air(removed)
+	ion_trail.generate_effect()
 
 	return TRUE
 

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -132,6 +132,7 @@
 	. = ..()
 	if(!ion_trail)
 		ion_trail = new
+		ion_trail.auto_process = FALSE
 	ion_trail.set_up(M)
 
 /obj/item/organ/cyberimp/chest/thrusters/Remove(mob/living/carbon/M, special = 0)
@@ -152,12 +153,14 @@
 		if(allow_thrust(0.01))
 			ion_trail.start()
 			RegisterSignal(owner, COMSIG_MOVABLE_MOVED, .proc/move_react)
+			RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, .proc/pre_move_react)
 			owner.add_movespeed_modifier(MOVESPEED_ID_CYBER_THRUSTER, priority=100, multiplicative_slowdown=-0.5, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
 			if(!silent)
 				to_chat(owner, "<span class='notice'>You turn your thrusters set on.</span>")
 	else
 		ion_trail.stop()
 		UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
+		UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 		owner.remove_movespeed_modifier(MOVESPEED_ID_CYBER_THRUSTER)
 		if(!silent)
 			to_chat(owner, "<span class='notice'>You turn your thrusters set off.</span>")
@@ -197,12 +200,14 @@
 	// Priority 1: use air from environment.
 	var/datum/gas_mixture/environment = T.return_air()
 	if(environment && environment.return_pressure() > 30)
+		ion_trail.generate_effect()
 		return 1
 
 	// Priority 2: use plasma from internal plasma storage.
 	// (just in case someone would ever use this implant system to make cyber-alien ops with jetpacks and taser arms)
 	if(owner.getPlasma() >= num*100)
 		owner.adjustPlasma(-num*100)
+		ion_trail.generate_effect()
 		return 1
 
 	// Priority 3: use internals tank.
@@ -211,9 +216,11 @@
 		var/datum/gas_mixture/removed = I.air_contents.remove(num)
 		if(removed.total_moles() > 0.005)
 			T.assume_air(removed)
+			ion_trail.generate_effect()
 			return 1
 		else
 			T.assume_air(removed)
+			ion_trail.generate_effect()
 
 	toggle(silent = TRUE)
 	return 0


### PR DESCRIPTION

## About The Pull Request

Jets generate trails only on use.

## Why It's Good For The Game

Cool trails.

## Changelog
:cl:
tweak: Now jets generate trails only on use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
